### PR TITLE
Use rational expressions to compare sessions now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>dk.brics</groupId>
+            <artifactId>automaton</artifactId>
+            <version>1.12-4</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.16.0</version>

--- a/src/main/java/mychor/Communication.java
+++ b/src/main/java/mychor/Communication.java
@@ -116,6 +116,7 @@ public class Communication {
 
     @Override
     public boolean equals(Object o){
+        if(this == o) return true;
         if (!(o instanceof Communication comp)) return false;
         if(!(direction == comp.direction && Objects.equals(label, comp.label))) return false;
         //handling recursive branches
@@ -381,5 +382,55 @@ public class Communication {
             recursiveCallersTo.addAll(nextNode.getRecursiveCallersTo(comm));
         }
         return recursiveCallersTo;
+    }
+
+    public void removeInPlace(Communication dummy) {
+        for (Communication nextCommunicationNode : nextCommunicationNodes) {
+            nextCommunicationNode.removeInPlace(dummy);
+        }
+        var wasHere = nextCommunicationNodes.remove(dummy);
+        if(wasHere){
+            nextCommunicationNodes.addAll(dummy.nextCommunicationNodes);
+            nextCommunicationNodes.addAll(dummy.getNextCommunicationNodes());
+            recursiveCallees.addAll(dummy.getRecursiveCallees());
+        }
+
+        wasHere = recursiveCallees.remove(dummy);
+        if(wasHere){
+            recursiveCallees.remove(dummy);
+            recursiveCallees.addAll(dummy.getNextCommunicationNodes());
+            recursiveCallees.addAll(dummy.getRecursiveCallees());
+        }
+    }
+
+    public void replace2(Communication toReplace, Communication replacer){
+        var wasHere = nextCommunicationNodes.remove(toReplace);
+        if(wasHere){
+            recursiveCallees.add(replacer);
+        }
+        wasHere = recursiveCallees.remove(toReplace);
+        if(wasHere) recursiveCallees.add(replacer);
+
+        for (Communication nextCommunicationNode : nextCommunicationNodes) {
+            nextCommunicationNode.replace2(toReplace, replacer);
+        }
+    }
+
+    public void replace(Communication toReplace, Communication replacer) {
+        var wasHere = nextCommunicationNodes.remove(toReplace);
+        if(wasHere){
+            if(nodeIsAbove(replacer)){
+                recursiveCallees.add(replacer);
+            }else if(nodeIsBelow(replacer)){
+                System.out.println("probel");
+            }else{
+                nextCommunicationNodes.add(replacer);
+            }
+        }
+        wasHere = recursiveCallees.remove(toReplace);
+        if(wasHere) recursiveCallees.add(replacer);
+        for (Communication nextCommunicationNode : nextCommunicationNodes) {
+            nextCommunicationNode.replace(toReplace, replacer);
+        }
     }
 }

--- a/src/main/java/mychor/Generators/GRPCGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCGenerator.java
@@ -1,0 +1,46 @@
+package mychor.Generators;
+
+import mychor.Session;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.locks.ReentrantLock;
+
+public abstract class GRPCGenerator implements Generator{
+    String serviceName;
+    String protoName;
+    Session session;
+    boolean alreadySetup = false;
+    String packageName = "grpc";
+    static long generatorCounter = 0;
+    static ReentrantLock setupLock = new ReentrantLock();
+    static ReentrantLock messageLock = new ReentrantLock();
+    ArrayBlockingQueue<Long> counterQueue = new ArrayBlockingQueue<>(100);
+
+    public GRPCGenerator(Session serviceSession) {
+        session = serviceSession;
+        protoName = "GrpcService";
+        serviceName = "GRPCService";
+    }
+
+    protected ArrayList<String> generateClass(String service, String applicationPath, String rpc) throws IOException {
+        var proto = String.format("""
+                syntax = "proto3";
+                package grpc;
+                message Message {
+                  string msg = 1;
+                }
+                service %s {
+                  %s
+                }""", serviceName, rpc);
+        Files.createDirectories(Paths.get(applicationPath,service, "src", "main", "proto"));
+        Files.write(Path.of(
+                        applicationPath,service, "src", "main", "proto",protoName+".proto"),
+                proto.getBytes());
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/mychor/Generators/GRPCStStClientGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCStStClientGenerator.java
@@ -5,10 +5,10 @@ import mychor.Session;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
-public class GRPCStStClientGenerator implements Generator {
+public class GRPCStStClientGenerator extends GRPCStStGenerator {
     public GRPCStStClientGenerator(Session serviceSession) {
+        super(serviceSession);
     }
 
     @Override
@@ -34,11 +34,6 @@ public class GRPCStStClientGenerator implements Generator {
     @Override
     public String generateVoid(Comm comm) {
         return "";
-    }
-
-    @Override
-    public ArrayList<String> generateClass(String service, String applicationPath) throws IOException {
-        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/mychor/Generators/GRPCStStGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCStStGenerator.java
@@ -1,0 +1,23 @@
+package mychor.Generators;
+
+import mychor.Session;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.locks.ReentrantLock;
+
+public abstract class GRPCStStGenerator extends GRPCGenerator {
+
+    public GRPCStStGenerator(Session serviceSession){
+        super(serviceSession);
+    }
+
+    @Override
+    public ArrayList<String> generateClass(String service, String applicationPath) throws IOException {
+        return super.generateClass(service, applicationPath, "rpc Communicate(stream Message) returns (stream Message);");
+    }
+}

--- a/src/main/java/mychor/Generators/GRPCStStServerGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCStStServerGenerator.java
@@ -7,8 +7,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GRPCStStServerGenerator implements Generator {
+public class GRPCStStServerGenerator extends GRPCStStGenerator {
     public GRPCStStServerGenerator(Session serviceSession) {
+        super(serviceSession);
     }
 
     @Override
@@ -34,11 +35,6 @@ public class GRPCStStServerGenerator implements Generator {
     @Override
     public String generateVoid(Comm comm) {
         return "";
-    }
-
-    @Override
-    public ArrayList<String> generateClass(String service, String applicationPath) throws IOException {
-        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/mychor/Generators/GRPCStUnClientGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCStUnClientGenerator.java
@@ -42,6 +42,6 @@ public class GRPCStUnClientGenerator extends GRPCStUnGenerator {
 
     @Override
     public ArrayList<String> generateMainImports() {
-        return null;
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/mychor/Generators/GRPCStUnClientGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCStUnClientGenerator.java
@@ -3,7 +3,9 @@ package mychor.Generators;
 import mychor.Comm;
 import mychor.Session;
 
-public class GRPCStUnClientGenerator extends GRPCUnUnGenerator {
+import java.util.ArrayList;
+
+public class GRPCStUnClientGenerator extends GRPCStUnGenerator {
     public GRPCStUnClientGenerator(Session serviceSession) {
         super(serviceSession);
     }
@@ -36,5 +38,10 @@ public class GRPCStUnClientGenerator extends GRPCUnUnGenerator {
     @Override
     public String closeSession() {
         return "";
+    }
+
+    @Override
+    public ArrayList<String> generateMainImports() {
+        return null;
     }
 }

--- a/src/main/java/mychor/Generators/GRPCStUnGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCStUnGenerator.java
@@ -1,0 +1,17 @@
+package mychor.Generators;
+
+import mychor.Session;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public abstract class GRPCStUnGenerator extends GRPCGenerator {
+    public GRPCStUnGenerator(Session serviceSession) {
+        super(serviceSession);
+    }
+
+    @Override
+    public ArrayList<String> generateClass(String service, String applicationPath) throws IOException {
+        return super.generateClass(service, applicationPath, "rpc Communicate(stream Message) returns (Message);");
+    }
+}

--- a/src/main/java/mychor/Generators/GRPCStUnServerGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCStUnServerGenerator.java
@@ -3,7 +3,9 @@ package mychor.Generators;
 import mychor.Comm;
 import mychor.Session;
 
-public class GRPCStUnServerGenerator extends GRPCUnUnGenerator {
+import java.util.ArrayList;
+
+public class GRPCStUnServerGenerator extends GRPCStUnGenerator {
     public GRPCStUnServerGenerator(Session serviceSession) {
         super(serviceSession);
     }
@@ -36,5 +38,10 @@ public class GRPCStUnServerGenerator extends GRPCUnUnGenerator {
     @Override
     public String closeSession() {
         return "";
+    }
+
+    @Override
+    public ArrayList<String> generateMainImports() {
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/mychor/Generators/GRPCUnStClientGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCUnStClientGenerator.java
@@ -3,7 +3,7 @@ package mychor.Generators;
 import mychor.Comm;
 import mychor.Session;
 
-public class GRPCUnStClientGenerator extends GRPCUnUnGenerator {
+public class GRPCUnStClientGenerator extends GRPCUnStGenerator {
     public GRPCUnStClientGenerator(Session serviceSession) {
         super(serviceSession);
     }

--- a/src/main/java/mychor/Generators/GRPCUnStGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCUnStGenerator.java
@@ -1,0 +1,25 @@
+package mychor.Generators;
+
+import mychor.Session;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class GRPCUnStGenerator extends GRPCGenerator{
+    public GRPCUnStGenerator(Session serviceSession) {
+        super(serviceSession);
+    }
+
+    @Override
+    public ArrayList<String> generateMainImports() {
+        return new ArrayList<>(List.of(
+                "import java.util.concurrent.SynchronousQueue;"
+        ));
+    }
+
+    @Override
+    public ArrayList<String> generateClass(String service, String applicationPath) throws IOException {
+        return super.generateClass(service, applicationPath, "rpc Communicate(Message) returns (stream Message);");
+    }
+}

--- a/src/main/java/mychor/Generators/GRPCUnUnGenerator.java
+++ b/src/main/java/mychor/Generators/GRPCUnUnGenerator.java
@@ -12,21 +12,9 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.locks.ReentrantLock;
 
-public abstract class GRPCUnUnGenerator implements Generator{
-    String serviceName;
-    String protoName;
-    Session session;
-    boolean alreadySetup = false;
-    String packageName = "grpc";
-    static long generatorCounter = 0;
-    static ReentrantLock setupLock = new ReentrantLock();
-    static ReentrantLock messageLock = new ReentrantLock();
-    ArrayBlockingQueue<Long> counterQueue = new ArrayBlockingQueue<>(100);
-
+public abstract class GRPCUnUnGenerator extends GRPCGenerator {
     public GRPCUnUnGenerator(Session serviceSession) {
-        session = serviceSession;
-        protoName = "GrpcService";
-        serviceName = "GRPCService";
+        super(serviceSession);
     }
 
     @Override
@@ -38,19 +26,6 @@ public abstract class GRPCUnUnGenerator implements Generator{
 
     @Override
     public ArrayList<String> generateClass(String service, String applicationPath) throws IOException {
-        var proto = String.format("""
-                syntax = "proto3";
-                package grpc;
-                message Message {
-                  string msg = 1;
-                }
-                service %s {
-                  rpc Communicate(Message) returns (Message);
-                }""", serviceName);
-        Files.createDirectories(Paths.get(applicationPath,service, "src", "main", "proto"));
-        Files.write(Path.of(
-                        applicationPath,service, "src", "main", "proto",protoName+".proto"),
-                proto.getBytes());
-        return new ArrayList<>();
+        return super.generateClass(service, applicationPath, "rpc Communicate(Message) returns (Message);");
     }
 }

--- a/src/main/java/mychor/Generators/Generator.java
+++ b/src/main/java/mychor/Generators/Generator.java
@@ -4,7 +4,6 @@ import mychor.Comm;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 
 public interface Generator {
     String generateSend(Comm comm);

--- a/src/main/java/mychor/PatternDetector.java
+++ b/src/main/java/mychor/PatternDetector.java
@@ -1,14 +1,7 @@
 package mychor;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import mychor.Generators.GenerationConfig;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 
@@ -18,6 +11,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import static mychor.automata.PatternUtils.pattern2DFA;
 
 public class PatternDetector {
 
@@ -60,7 +55,7 @@ public class PatternDetector {
     }
 
     public boolean testCompatibility(Session target, Session template){
-        return template.supports(target);
+        return pattern2DFA(target).subsetOf(pattern2DFA(template));
     }
 
     public HashMap<Session, List<String>> detectCompatibleFrameworks() {

--- a/src/main/java/mychor/Session.java
+++ b/src/main/java/mychor/Session.java
@@ -1,5 +1,6 @@
 package mychor;
 
+import java.nio.channels.SeekableByteChannel;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -160,6 +161,7 @@ public record Session(String peerA, String peerB, ArrayList<Communication> commu
             }
         }else{
             //not called
+            ctx.currentDummy = null;
             ctx.recursiveCommunicationsEntrypoint.put(call.variableName, new HashMap<>());
             ctx.lastVariable = call.variableName;
             fromBehaviour(nextBehaviour, ctx);
@@ -167,14 +169,90 @@ public record Session(String peerA, String peerB, ArrayList<Communication> commu
     }
 
     private static void processCdt(SmallContext ctx, Cdt cdt) {
+        var dummies = new ArrayList<Communication>();
         var ctxs = new ArrayList<SmallContext>();
         for (String s : cdt.nextBehaviours.keySet()) {
             var newCtx = new SmallContext(ctx);
             newCtx.recursiveCommunicationsEntrypoint = ctx.recursiveCommunicationsEntrypoint;
+            if(ctx.lastVariable != null){
+                Communication dummy = new Communication(Utils.Direction.DUMMY);
+                dummies.add(dummy);
+                newCtx.currentDummy = dummy;
+            }
             fromBehaviour(cdt.nextBehaviours.get(s), newCtx);
             ctxs.add(newCtx);
         }
-        ctx = SmallContext.mergeHorizontalStub(ctxs).mergeWithPrevious();
+        var  topDummy = new Communication(Utils.Direction.DUMMY);
+        //replace all Dummies with Single Dummy
+        if(dummies.size() > 1){
+            var dummy1 = dummies.getFirst();
+            var ctx1 = ctxs.getFirst();
+            var dummy2 = dummies.getLast();
+            var ctx2 = ctxs.getLast();
+            topDummy.addNextCommunicationNodes(new ArrayList<>(dummy1.getNextCommunicationNodes()));
+            for (Communication recursiveCallee : dummy1.getRecursiveCallees()) {
+                topDummy.addRecursiveCallee(recursiveCallee);
+            }
+            topDummy.addNextCommunicationNodes(new ArrayList<>(dummy2.getNextCommunicationNodes()));
+            for (Communication recursiveCallee : dummy2.getRecursiveCallees()) {
+                topDummy.addRecursiveCallee(recursiveCallee);
+            }
+
+
+            for (Session session : ctx1.sessions) {
+                session.replace2(dummy2, topDummy);
+                session.replace(dummy1, topDummy);
+            }
+            for (Session session : ctx2.sessions) {
+                session.replace2(dummy1, topDummy);
+                session.replace(dummy2, topDummy);
+            }
+            ctx = SmallContext.mergeHorizontalStub(ctxs).mergeWithPrevious();
+            for (Session session : ctx.sessions) {
+                session.removeInPlace(topDummy);
+            }
+        }else{
+            ctx = SmallContext.mergeHorizontalStub(ctxs).mergeWithPrevious();
+        }
+    }
+
+    private void replace2(Communication toReplace, Communication replacer){
+        for (Communication recursiveCallee : toReplace.getRecursiveCallees()) {
+            replacer.addRecursiveCallee(recursiveCallee);
+        }
+        var wasHere = communicationsRoots.remove(toReplace);
+        if(wasHere) communicationsRoots.add(replacer);
+        for (Communication communicationsRoot : communicationsRoots) {
+            communicationsRoot.replace2(toReplace, replacer);
+        }
+
+    }
+
+    private void replace(Communication toReplace, Communication replacer) {
+        for (Communication recursiveCallee : toReplace.getRecursiveCallees()) {
+            replacer.addRecursiveCallee(recursiveCallee);
+        }
+        var wasHere = communicationsRoots.remove(toReplace);
+        if(wasHere) communicationsRoots.add(replacer);
+        for (Communication communicationsRoot : communicationsRoots) {
+            communicationsRoot.replace(toReplace, replacer);
+        }
+    }
+
+    private void removeInPlace(Communication dummy) {
+        var found = false;
+        for (int i = 0; i < communicationsRoots.size(); i++) {
+            communicationsRoots.get(i).removeInPlace(dummy);
+            if(communicationsRoots.get(i) == dummy){
+                found = true;
+            }
+        }
+        if(found){
+            while(communicationsRoots.remove(dummy)){
+                communicationsRoots.remove(dummy);
+            }
+            communicationsRoots.addAll(dummy.getNextCommunicationNodes());
+        }
     }
 
     private static void processComm(SmallContext ctx, Comm comm) {
@@ -187,6 +265,25 @@ public record Session(String peerA, String peerB, ArrayList<Communication> commu
                 lastVariable != null &&
                         ctx.recursiveCommunicationsEntrypoint.containsKey(lastVariable) &&
                                 !ctx.recursiveCommunicationsEntrypoint.get(lastVariable).containsKey(sessionKey);
+        if(ctx.currentDummy != null){
+            mustUpdateRecursiveCommunicationsEntrypoint = false;
+            if(lastVariable != null){
+                if(ctx.recursiveCommunicationsEntrypoint.get(lastVariable).containsKey(sessionKey)){
+                    ctx.recursiveCommunicationsEntrypoint.get(lastVariable).get(sessionKey).add(ctx.currentDummy);
+                }else{
+                    ctx.recursiveCommunicationsEntrypoint.get(lastVariable)
+                            .put(sessionKey, new ArrayList<>(List.of(ctx.currentDummy)));
+                }
+            }
+            var maybeSession = ctx.sessions.stream().filter(s -> s.peerA().equals(peerA) && s.peerB.equals(peerB)).findFirst();
+            if(maybeSession.isPresent()){
+                maybeSession.get().addLeafCommunicationRoots(new ArrayList<>(List.of(ctx.currentDummy)));
+            }else{
+                ctx.sessions.add(new Session(peerA, peerB, new ArrayList<>(List.of(ctx.currentDummy))));
+            }
+            ctx.currentDummy = null;
+        }
+
         if(direction.equals(Utils.Direction.BRANCH)){
             //There can be several nextNodes
             var ctxs = new ArrayList<SmallContext>();
@@ -194,6 +291,7 @@ public record Session(String peerA, String peerB, ArrayList<Communication> commu
                     .map(label -> new Communication(Utils.Direction.BRANCH, label)).toList();
             if(mustUpdateRecursiveCommunicationsEntrypoint){
                 ctx.recursiveCommunicationsEntrypoint.get(lastVariable).put(sessionKey, new ArrayList<>(comms));
+                ctx.lastVariable = null;
             }
             for (Communication communication : comms) {
                 var newCtx = new SmallContext(ctx);
@@ -222,6 +320,7 @@ public record Session(String peerA, String peerB, ArrayList<Communication> commu
             }
             if(mustUpdateRecursiveCommunicationsEntrypoint){
                 ctx.recursiveCommunicationsEntrypoint.get(lastVariable).put(sessionKey, new ArrayList<>(List.of(co)));
+                ctx.lastVariable = null;
             }
             if(!comm.nextBehaviours.isEmpty()){
                 fromBehaviour(comm.nextBehaviours.get(nextBehaviourKey), ctx);
@@ -243,6 +342,8 @@ public record Session(String peerA, String peerB, ArrayList<Communication> commu
         public String lastVariable = null;
         public HashMap<String, HashMap<String, ArrayList<Communication>>> recursiveCommunicationsEntrypoint = new HashMap<>();
         public SmallContext previousContext;
+        public boolean mustUpdateRecursiveCommunicationsEntrypoint = false;
+        public Communication currentDummy;
 
         public SmallContext(){};
         public SmallContext(
@@ -263,6 +364,25 @@ public record Session(String peerA, String peerB, ArrayList<Communication> commu
         }
         public SmallContext(SmallContext previousContext){
             this.previousContext = previousContext;
+        }
+
+        public SmallContext duplicate(){
+            var sm = new SmallContext();
+            sm.sessions = new ArrayList<>(this.sessions);
+            sm.calledVariables = new HashSet<>(this.calledVariables);
+            sm.lastVariable = this.lastVariable;
+            sm.recursiveCommunicationsEntrypoint = new HashMap<>();
+            for (String s : recursiveCommunicationsEntrypoint.keySet()) {
+                var hm = new HashMap<String, ArrayList<Communication>>();
+                var hmsource = recursiveCommunicationsEntrypoint.get(s);
+                for (String string : hmsource.keySet()) {
+                    hm.put(s, new ArrayList<>(hmsource.get(string)));
+                }
+                sm.recursiveCommunicationsEntrypoint.put(s, hm);
+            }
+            sm.previousContext = previousContext;
+            sm.mustUpdateRecursiveCommunicationsEntrypoint = mustUpdateRecursiveCommunicationsEntrypoint;
+            return sm;
         }
 
         public boolean alreadyCalledVariable(String variable){

--- a/src/main/java/mychor/Utils.java
+++ b/src/main/java/mychor/Utils.java
@@ -8,7 +8,8 @@ public class Utils {
         RECEIVE,
         SELECT,
         BRANCH,
-        VOID
+        VOID,
+        DUMMY
     }
 
     public static String capitalize(String str){

--- a/src/main/java/mychor/automata/PatternUtils.java
+++ b/src/main/java/mychor/automata/PatternUtils.java
@@ -1,0 +1,76 @@
+package mychor.automata;
+import dk.brics.automaton.Automaton;
+import dk.brics.automaton.State;
+import dk.brics.automaton.Transition;
+import mychor.Communication;
+import mychor.Session;
+
+import mychor.Utils;
+
+import java.util.HashMap;
+
+public class PatternUtils {
+    static boolean allRecursiveCallsAreFinalStates = false;
+    static HashMap<Communication, State> communicationStatesRepo;
+    public static char getCommunicationChar(Communication c){
+        if(c.getDirection() == Utils.Direction.SEND || c.getDirection() == Utils.Direction.SELECT){
+            return 's';
+        }else if(c.getDirection() == Utils.Direction.RECEIVE || c.getDirection() == Utils.Direction.BRANCH){
+            return 'r';
+        }else{
+            return 0;
+        }
+    }
+    public static Automaton pattern2DFA(Session s){
+        communicationStatesRepo = new HashMap<>();
+        State startState = new State();
+        for (Communication communicationsRoot : s.communicationsRoots()) {
+            var state = traverseIt(communicationsRoot);
+            if(state.isAccept()) {
+                startState.setAccept(true);
+            }
+            for (Transition transition : state.getTransitions()) {
+                startState.addTransition(transition);
+            }
+        }
+        var auto = new Automaton();
+        auto.setInitialState(startState);
+        auto.setDeterministic(false);
+        return auto;
+    }
+    public static Automaton pattern2DFA(Communication c){
+        communicationStatesRepo = new HashMap<>();
+        State startState = traverseIt(c);
+        var auto = new Automaton();
+        auto.setInitialState(startState);
+        auto.setDeterministic(false);
+        return auto;
+    }
+
+    private static State traverseIt(Communication c){
+        var s1 = new State();
+        communicationStatesRepo.put(c, s1);
+        // recursion is not considered yet
+        if(getCommunicationChar(c) == 0){
+            s1.setAccept(true);
+            return s1;
+        }
+        if(c.isFinal()){
+            var s2 = new State();
+            s2.setAccept(true);
+            s1.addTransition(new Transition(getCommunicationChar(c), s2));
+        }else{
+            for (Communication nextCommunicationNode : c.getNextCommunicationNodes()) {
+                var nextState = traverseIt(nextCommunicationNode);
+                s1.addTransition(new Transition(getCommunicationChar(c), nextState));
+            }
+        }
+        for (Communication recursiveCallee : c.getRecursiveCallees()) {
+            if(allRecursiveCallsAreFinalStates){
+                s1.setAccept(true);
+            }
+            s1.addTransition(new Transition(getCommunicationChar(c), communicationStatesRepo.get(recursiveCallee)));
+        }
+        return s1;
+    }
+}

--- a/src/main/resources/messaging-patterns/patterns.json
+++ b/src/main/resources/messaging-patterns/patterns.json
@@ -202,7 +202,8 @@
           ]
         }
       },
-      "class": ""
+      "class": "",
+      "generator" : "GeneratorStStClient"
     },
     "server" : {
       "needsClass": true,
@@ -221,7 +222,8 @@
           ]
         }
       },
-      "class": ""
+      "class": "",
+      "generator" : "GeneratorStStServer"
     }
   }
 ]

--- a/src/test/antlr4/SP_programs/receive_or_recursive_send.sp
+++ b/src/test/antlr4/SP_programs/receive_or_recursive_send.sp
@@ -1,0 +1,10 @@
+client [ Call Client ]
+
+Client:
+    If check(e)
+    Then
+        server?data @?"";
+        End
+    Else
+        server!data @!"";
+        Call Client

--- a/src/test/antlr4/SP_programs/recursive_request_response.sp
+++ b/src/test/antlr4/SP_programs/recursive_request_response.sp
@@ -11,9 +11,13 @@ client [
 Server :
     client?req @?"";
     client!response @!"";
-    Call Server
+    If check(x)
+    Then Call Server
+    Else End
 
 Client :
     server! request@!"";
     server? response@?"";
-    Call Client
+    If check(x)
+    Then Call Client
+    Else End

--- a/src/test/antlr4/SP_programs/request_several_response.sp
+++ b/src/test/antlr4/SP_programs/request_several_response.sp
@@ -1,0 +1,30 @@
+client [ Call Client ] | server [ Call Server ]
+
+Client :
+    server!data @!"";
+    Call StreamResponseClient
+
+StreamResponseClient:
+    server&
+    { "continue" :
+     Some(
+        server?data @?"";
+        Call StreamResponseClient
+     )}
+    //
+    { "end" : None}
+
+Server :
+    client?data @?"";
+    Call StreamResponseServer
+
+StreamResponseServer:
+    client!data@!"";
+    If check(x)
+    Then
+        client+"continue" @+"";
+        client!data @!"";
+        Call StreamResponseServer
+    Else
+        client+"end" @+"";
+        End

--- a/src/test/antlr4/SP_programs/server_request_one_response.sp
+++ b/src/test/antlr4/SP_programs/server_request_one_response.sp
@@ -1,0 +1,29 @@
+client [ Call Client ] | server [ Call Server ]
+
+Client :
+    Call StreamRequestClient
+
+StreamRequestClient:
+    If check(x)
+    Then
+        server+"continue" @+"";
+        server!data @!"";
+        Call StreamRequestClient
+    Else
+        server+"end" @+"";
+        server?answer @?"";
+        End
+
+
+Server :
+    client&
+    { "continue" : Some(
+        client?request@?"";
+        Call Server
+    )}
+    //
+    { "end" : Some(
+        client!response@!"";
+        End
+    )}
+

--- a/src/test/java/CodeGenerationTest.java
+++ b/src/test/java/CodeGenerationTest.java
@@ -87,7 +87,7 @@ public class CodeGenerationTest extends ProgramReaderTest{
 
     @Test
     public void basicGRPC_st_unShouldCreateProtoFilesAndServerAndClient() throws IOException {
-        var ctx = testFile("recursive_request_response.sp").compilerCtx;
+        var ctx = testFile("server_request_one_response.sp").compilerCtx;
         var generator = new SPCodeGeneratorB(ctx, path, name, List.of("GRPC_st_un_server","GRPC_st_un_client"));
         generator.generateCode();
         assertTrue(generator.necessaryFrameworks.containsAll(List.of(
@@ -101,7 +101,7 @@ public class CodeGenerationTest extends ProgramReaderTest{
 
     @Test
     public void basicGRPC_un_stShouldCreateProtoFilesAndServerAndClient() throws IOException {
-        var ctx = testFile("recursive_request_response.sp").compilerCtx;
+        var ctx = testFile("request_several_response.sp").compilerCtx;
         var generator = new SPCodeGeneratorB(ctx, path, name, List.of("GRPC_un_st_server","GRPC_un_st_client"));
         generator.generateCode();
         assertTrue(generator.necessaryFrameworks.containsAll(List.of(

--- a/src/test/java/CommunicationTest.java
+++ b/src/test/java/CommunicationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static mychor.automata.PatternUtils.pattern2DFA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -615,37 +616,37 @@ public class CommunicationTest {
         public void sendSupportsSelect(){
             var send = new Communication(Utils.Direction.SEND);
             var select = new Communication(Utils.Direction.SELECT, "GET");
-            assertTrue(send.supports(select));
+            assertTrue(pattern2DFA(select).subsetOf(pattern2DFA(send)));
         }
         @Test
         public void sendSupportsSend(){
             var send = new Communication(Utils.Direction.SEND);
             var send2 = new Communication(Utils.Direction.SEND);
-            assertTrue(send.supports(send2));
+            assertTrue(pattern2DFA(send2).subsetOf(pattern2DFA(send)));
         }
         @Test
         public void receiveSupportsReceive(){
             var rcv1 = new Communication(Utils.Direction.RECEIVE);
             var rcv2 = new Communication(Utils.Direction.RECEIVE);
-            assertTrue(rcv1.supports(rcv2));
+            assertTrue(pattern2DFA(rcv2).subsetOf(pattern2DFA(rcv1)));
         }
         @Test
         public void receiveSupportsBranch(){
             var rcv1 = new Communication(Utils.Direction.RECEIVE);
             var rcv2 = new Communication(Utils.Direction.BRANCH, "GET");
-            assertTrue(rcv1.supports(rcv2));
+            assertTrue(pattern2DFA(rcv2).subsetOf(pattern2DFA(rcv1)));
         }
         @Test
         public void sendDoesntSupportReceive(){
             var send = new Communication(Utils.Direction.SEND);
             var rcv = new Communication(Utils.Direction.RECEIVE);
-            assertFalse(send.supports(rcv));
+            assertFalse(pattern2DFA(rcv).subsetOf(pattern2DFA(send)));
         }
         @Test
         public void sendDoesntSupportBranch(){
             var send = new Communication(Utils.Direction.SEND);
             var brch = new Communication(Utils.Direction.BRANCH, "GET");
-            assertFalse(send.supports(brch));
+            assertFalse(pattern2DFA(brch).subsetOf(pattern2DFA(send)));
         }
         @Test
         public void voidSupportsOnlyVoid(){
@@ -655,18 +656,18 @@ public class CommunicationTest {
             var rcv = new Communication(Utils.Direction.RECEIVE);
             var select = new Communication(Utils.Direction.SELECT,"GET");
             var brch = new Communication(Utils.Direction.BRANCH, "GET");
-            assertFalse(v.supports(send));
-            assertFalse(v.supports(rcv));
-            assertFalse(v.supports(select));
-            assertFalse(v.supports(brch));
-            assertTrue(v.supports(v2));
+            assertFalse(pattern2DFA(send).subsetOf(pattern2DFA(v)));
+            assertFalse(pattern2DFA(rcv).subsetOf(pattern2DFA(v)));
+            assertFalse(pattern2DFA(select).subsetOf(pattern2DFA(v)));
+            assertFalse(pattern2DFA(brch).subsetOf(pattern2DFA(v)));
+            assertTrue(pattern2DFA(v2).subsetOf(pattern2DFA(v)));
         }
         @Test
         public void singleSendShouldNotSupportRecursiveSend(){
             var singleSend = new Communication(Utils.Direction.SEND);
             var recursiveSend = new Communication(Utils.Direction.SEND);
             recursiveSend.addLeafCommunicationRoots(new ArrayList<>(List.of(recursiveSend)));
-            assertFalse(singleSend.supports(recursiveSend));
+            assertFalse(pattern2DFA(recursiveSend).subsetOf(pattern2DFA(singleSend)));
         }
         @Test
         public void nonEmptyNonVoidNextNodesDoesntSupportEmpytNodes(){
@@ -674,7 +675,7 @@ public class CommunicationTest {
             var com2 = new Communication(Utils.Direction.SEND);
             var cChild = new Communication(Utils.Direction.RECEIVE);
             com2.addLeafCommunicationRoots(new ArrayList<>(List.of(cChild)));
-            assertFalse(com2.supports(com1));
+            assertFalse(pattern2DFA(com1).subsetOf(pattern2DFA(com2)));
         }
         @Test
         public void empytNodesDoesntSupportnonEmptyNonVoidNextNodes(){
@@ -682,7 +683,7 @@ public class CommunicationTest {
             var com2 = new Communication(Utils.Direction.SEND);
             var cChild = new Communication(Utils.Direction.RECEIVE);
             com2.addLeafCommunicationRoots(new ArrayList<>(List.of(cChild)));
-            assertFalse(com1.supports(com2));
+            assertFalse(pattern2DFA(com2).subsetOf(pattern2DFA(com1)));
         }
         @Test
         public void deepCommunicationsSupport(){
@@ -692,7 +693,7 @@ public class CommunicationTest {
             var com21 = new Communication(Utils.Direction.RECEIVE);
             com1.addLeafCommunicationRoots(new ArrayList<>(List.of(com11)));
             com2.addLeafCommunicationRoots(new ArrayList<>(List.of(com21)));
-            assertTrue(com1.supports(com2));
+            assertTrue(pattern2DFA(com2).subsetOf(pattern2DFA(com1)));
         }
         @Test
         public void deepCommunicationsNonSupport(){
@@ -702,7 +703,7 @@ public class CommunicationTest {
             var com21 = new Communication(Utils.Direction.SEND);
             com1.addLeafCommunicationRoots(new ArrayList<>(List.of(com11)));
             com2.addLeafCommunicationRoots(new ArrayList<>(List.of(com21)));
-            assertFalse(com1.supports(com2));
+            assertFalse(pattern2DFA(com2).subsetOf(pattern2DFA(com1)));
         }
         @Test
         public void recursiveSendShouldSupportsDoubleSend(){
@@ -714,7 +715,7 @@ public class CommunicationTest {
             var com2 = new Communication(Utils.Direction.SEND);
             var com21 = new Communication(Utils.Direction.SEND);
             com2.addLeafCommunicationRoots(new ArrayList<>(List.of(com21)));
-            assertTrue(com1.supports(com2));
+            assertTrue(pattern2DFA(com2).subsetOf(pattern2DFA(com1)));
         }
         @Test
         public void recursiveSendDoesntSupportsPresenceOfReceive(){
@@ -726,7 +727,7 @@ public class CommunicationTest {
             var com2 = new Communication(Utils.Direction.SEND,
                     new Communication(Utils.Direction.SEND,
                             new Communication(Utils.Direction.RECEIVE)));
-            assertFalse(com1.supports(com2));
+            assertFalse(pattern2DFA(com2).subsetOf(pattern2DFA(com1)));
         }
         @Test
         public void recursiveSendWithoutVoidEscapeDoesntSupportsDoubleSend(){
@@ -735,7 +736,7 @@ public class CommunicationTest {
             var com2 = new Communication(Utils.Direction.SEND);
             var com21 = new Communication(Utils.Direction.SEND);
             com2.addLeafCommunicationRoots(new ArrayList<>(List.of(com21)));
-            assertFalse(com1.supports(com2));
+            assertFalse(pattern2DFA(com2).subsetOf(pattern2DFA(com1)));
         }
     }
 }

--- a/src/test/java/PatternDetectionTest.java
+++ b/src/test/java/PatternDetectionTest.java
@@ -14,6 +14,8 @@ import java.util.Map;
 
 import static mychor.Utils.Direction.RECEIVE;
 import static mychor.Utils.Direction.SEND;
+import static mychor.Utils.Direction.VOID;
+import static mychor.automata.PatternUtils.pattern2DFA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,45 +34,45 @@ public class PatternDetectionTest extends ProgramReaderTest{
             Session template = new Session("a", "b", new Communication(Utils.Direction.SEND));
             Session target = new Session("a", "b", new Communication(Utils.Direction.SEND));
 
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void sendShouldSupportsSelect(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.SEND));
             Session target = new Session("a", "b", new Communication(Utils.Direction.SELECT, "GET"));
 
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void selectShouldSupportsSend(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.SELECT, "GET"));
             Session target = new Session("a", "b", new Communication(Utils.Direction.SEND));
 
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void sendShouldNotSupportsReceive(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.SEND));
             Session target = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void sendShouldNotSupportsBranch(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.SEND));
             Session target = new Session("a", "b", new Communication(Utils.Direction.BRANCH, "left"));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void selectShouldNotSupportsReceive(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.SELECT, "GET"));
             Session target = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void selectShouldNotSupportsBranch(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.SELECT, "left"));
             Session target = new Session("a", "b", new Communication(Utils.Direction.BRANCH, "left"));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
     }
 
@@ -81,43 +83,43 @@ public class PatternDetectionTest extends ProgramReaderTest{
         public void receiveShouldSupportsReceive(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
             Session target = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void receiveShouldSupportsBranch(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
             Session target = new Session("a", "b", new Communication(Utils.Direction.BRANCH, "GET"));
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void branchShouldSupportsReceive(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.BRANCH, "GET"));
             Session target = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void receiveShouldNotSupportsSend(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
             Session target = new Session("a", "b", new Communication(Utils.Direction.SEND));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void receiveShouldNotSupportsSelect(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.RECEIVE));
             Session target = new Session("a", "b", new Communication(Utils.Direction.SELECT, "left"));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void branchShouldNotSupportsSend(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.BRANCH, "GET"));
             Session target = new Session("a", "b", new Communication(Utils.Direction.SEND));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void branchShouldNotSupportsSelect(){
             Session template = new Session("a", "b", new Communication(Utils.Direction.BRANCH, "left"));
             Session target = new Session("a", "b", new Communication(Utils.Direction.SELECT, "left"));
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
     }
 
@@ -127,25 +129,25 @@ public class PatternDetectionTest extends ProgramReaderTest{
         public void sendReceiveShouldSupportSendReceive(){
             var template = new Session("a","b", new Communication(Utils.Direction.SEND, new Communication(Utils.Direction.RECEIVE)));
             var target = new Session("a","b", new Communication(Utils.Direction.SEND, new Communication(Utils.Direction.RECEIVE)));
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void sendSendShouldSupportSendSend(){
             var template = new Session("a","b", new Communication(Utils.Direction.SEND, new Communication(Utils.Direction.SEND)));
             var target = new Session("a","b", new Communication(Utils.Direction.SEND, new Communication(Utils.Direction.SEND)));
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void receiveSendShouldSupportReceiveSend(){
             var template = new Session("a","b", new Communication(Utils.Direction.RECEIVE, new Communication(Utils.Direction.SEND)));
             var target = new Session("a","b", new Communication(Utils.Direction.RECEIVE, new Communication(Utils.Direction.SEND)));
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
         @Test
         public void receiveReceiveShouldSupportReceiveReceive(){
             var template = new Session("a","b", new Communication(Utils.Direction.RECEIVE, new Communication(Utils.Direction.RECEIVE)));
             var target = new Session("a","b", new Communication(Utils.Direction.RECEIVE, new Communication(Utils.Direction.RECEIVE)));
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
     }
 
@@ -154,12 +156,13 @@ public class PatternDetectionTest extends ProgramReaderTest{
         @Test
         public void recursiveSendShouldSupportRecursiveSend(){
             var send = new Communication(Utils.Direction.SEND);
-            send.addLeafCommunicationRoots((new ArrayList<>(List.of(send))));
+            send.addLeafCommunicationRoots((new ArrayList<>(List.of(send, new Communication(VOID)))));
             var send2 = new Communication(Utils.Direction.SEND);
-            send2.addLeafCommunicationRoots((new ArrayList<>(List.of(send2))));
+            send2.addLeafCommunicationRoots((new ArrayList<>(List.of(send2, new Communication(VOID)))));
             var template = new Session("a","b", send);
             var target = new Session("a","b", send2);
-            assertTrue(template.supports(target));
+            assertTrue(pattern2DFA(target).subsetOf(pattern2DFA(template)));
+            assertTrue(pattern2DFA(target).run("s"));
         }
 
         @Test
@@ -175,7 +178,7 @@ public class PatternDetectionTest extends ProgramReaderTest{
             recv2.addLeafCommunicationRoots((new ArrayList<>(List.of(recv2))));
             var template = new Session("a","b", send1);
             var target = new Session("a","b", send2);
-            assertFalse(template.supports(target));
+            assertFalse(pattern2DFA(target).subsetOf(pattern2DFA(template)));
         }
 
         @Test
@@ -185,8 +188,8 @@ public class PatternDetectionTest extends ProgramReaderTest{
 
             var send2 = new Communication(Utils.Direction.SEND);
             send2.addLeafCommunicationRoots(new ArrayList<>(List.of(send2)));
-            assertTrue(send1.supports(send2));
-            assertFalse(send2.supports(send1));
+            assertTrue(pattern2DFA(send2).subsetOf(pattern2DFA(send1)));
+            assertFalse(pattern2DFA(send1).subsetOf(pattern2DFA(send2)));
         }
 
         @Test
@@ -199,8 +202,8 @@ public class PatternDetectionTest extends ProgramReaderTest{
                     .filter(s -> s.peerA().equals("server")).toList().getFirst();
             var clientSession = recursivePingPong.sessions.stream()
                     .filter(s -> s.peerA().equals("client")).toList().getFirst();
-            assertTrue(grpcStStServerPattern.supports(serverSession));
-            assertTrue(grpcStStClientPattern.supports(clientSession));
+            assertTrue(pattern2DFA(serverSession).subsetOf(pattern2DFA(grpcStStServerPattern)));
+            assertTrue(pattern2DFA(clientSession).subsetOf(pattern2DFA(grpcStStClientPattern)));
         }
 
         @Test
@@ -213,8 +216,8 @@ public class PatternDetectionTest extends ProgramReaderTest{
                     .filter(s -> s.peerA().equals("server")).toList().getFirst();
             var clientSession = recursivePingPong.sessions.stream()
                     .filter(s -> s.peerA().equals("client")).toList().getFirst();
-            assertFalse(grpcStStServerPattern.supports(clientSession));
-            assertFalse(grpcStStClientPattern.supports(serverSession));
+            assertFalse(pattern2DFA(clientSession).subsetOf(pattern2DFA(grpcStStServerPattern)));
+            assertFalse(pattern2DFA(serverSession).subsetOf(pattern2DFA(grpcStStClientPattern)));
         }
 
         @Test
@@ -233,8 +236,8 @@ public class PatternDetectionTest extends ProgramReaderTest{
                                                             new Communication(Utils.Direction.SEND,
                                                                     new Communication(Utils.Direction.RECEIVE))))))));
             send2.addLeafCommunicationRoots(new ArrayList<>(List.of(send2)));
-            assertTrue(send1.supports(send2));
-            assertFalse(send2.supports(send1));
+            assertTrue(pattern2DFA(send2).subsetOf(pattern2DFA(send1)));
+            assertFalse(pattern2DFA(send1).subsetOf(pattern2DFA(send2)));
         }
 
         @Test
@@ -252,8 +255,8 @@ public class PatternDetectionTest extends ProgramReaderTest{
                                                     new Communication(Utils.Direction.RECEIVE,
                                                             new Communication(Utils.Direction.SEND,
                                                                     new Communication(Utils.Direction.SEND))))))));
-            assertFalse(send1.supports(send2));
-            assertFalse(send2.supports(send1));
+            assertFalse(pattern2DFA(send2).subsetOf(pattern2DFA(send1)));
+            assertFalse(pattern2DFA(send1).subsetOf(pattern2DFA(send2)));
         }
 
         @Test
@@ -282,7 +285,7 @@ public class PatternDetectionTest extends ProgramReaderTest{
             send21.addLeafCommunicationRoots(new ArrayList<>(List.of(send22)));
             send22.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv22)));
 
-            assertTrue(send11.supports(send21));
+            assertTrue(pattern2DFA(send21).subsetOf(pattern2DFA(send11)));
         }
 
         @Test
@@ -299,8 +302,8 @@ public class PatternDetectionTest extends ProgramReaderTest{
                                             new Communication(Utils.Direction.SEND,
                                                     new Communication(Utils.Direction.RECEIVE))))));
             send2.addLeafCommunicationRoots(new ArrayList<>(List.of(send2)));
-            assertTrue(send1.supports(send2));
-            assertFalse(send2.supports(send1));
+            assertTrue(pattern2DFA(send2).subsetOf(pattern2DFA(send1)));
+            assertFalse(pattern2DFA(send1).subsetOf(pattern2DFA(send2)));
         }
     }
 

--- a/src/test/java/PatternDetectionTest.java
+++ b/src/test/java/PatternDetectionTest.java
@@ -259,34 +259,6 @@ public class PatternDetectionTest extends ProgramReaderTest{
             assertFalse(pattern2DFA(send1).subsetOf(pattern2DFA(send2)));
         }
 
-        @Test
-        public void test2(){
-            var send11 = new Communication(Utils.Direction.SEND);
-            var rcv11 = new Communication(Utils.Direction.RECEIVE);
-            var send12 = new Communication(Utils.Direction.SEND);
-            send11.addLeafCommunicationRoots(new ArrayList<>(List.of(send11)));
-            send11.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv11)));
-            rcv11.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv11)));
-            send11.addLeafCommunicationRoots(new ArrayList<>(List.of(send12)));
-            send12.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv11)));
-
-            var send21 = new Communication(SEND);
-            var rcv21 = new Communication(RECEIVE);
-            var rcv22 = new Communication(RECEIVE);
-            var rcv23 = new Communication(RECEIVE);
-            var send22 = new Communication(SEND);
-            send21.addLeafCommunicationRoots(new ArrayList<>(List.of(send21)));
-            send21.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv21)));
-            send21.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv22)));
-            send21.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv23)));
-            rcv23.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv23)));
-            rcv23.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv22)));
-            rcv23.addLeafCommunicationRoots(new ArrayList<>(List.of(send21)));
-            send21.addLeafCommunicationRoots(new ArrayList<>(List.of(send22)));
-            send22.addLeafCommunicationRoots(new ArrayList<>(List.of(rcv22)));
-
-            assertTrue(pattern2DFA(send21).subsetOf(pattern2DFA(send11)));
-        }
 
         @Test
         public void test() {

--- a/src/test/java/Session2AutomatonTest.java
+++ b/src/test/java/Session2AutomatonTest.java
@@ -1,0 +1,198 @@
+import dk.brics.automaton.Automaton;
+import dk.brics.automaton.AutomatonProvider;
+import dk.brics.automaton.RegExp;
+import mychor.Communication;
+import mychor.Session;
+import mychor.Utils;
+import mychor.automata.PatternUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static mychor.Utils.Direction.VOID;
+import static mychor.automata.PatternUtils.pattern2DFA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Session2AutomatonTest extends ProgramReaderTest{
+
+    @Nested
+    class NonRecursiveTests{
+        @Test
+        public void simpleSendShouldReturn2statesAutomatonWishSTransition(){
+            Session s = new Session("a","b", new Communication(Utils.Direction.SEND));
+            var auto = pattern2DFA(s);
+            RegExp acceptedLanguage = new RegExp("s");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, auto);
+        }
+
+        @Test
+        public void cdtBranchingLeftShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/cdt_branching_left.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            assertTrue(automaton.run("") && automaton.run("r"));
+            RegExp acceptedLanguage = new RegExp("r?");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void cdtBranchingRightShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/cdt_branching_right.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            RegExp acceptedLanguage = new RegExp("r?");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void cdtBranchingBothShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/cdt_branching_both.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            RegExp acceptedLanguage = new RegExp("r");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void branchCdtMsgShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/branching_cdt_msg.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            RegExp acceptedLanguage = new RegExp("r(s|r)");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void branchingMsgBothShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/branching_message_both.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("server")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            RegExp acceptedLanguage = new RegExp("r(s|r)");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void branchingMsgRightShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/branching_message_right.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("server")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            RegExp acceptedLanguage = new RegExp("rr?");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void cdtSelectBothShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/cdt_select_both.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            RegExp acceptedLanguage = new RegExp("s");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void cdtSelectLeftShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/cdt_select_left.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            assertTrue(automaton.run("s") && automaton.run(""));
+            RegExp acceptedLanguage = new RegExp("s?");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void cdtSelectRightShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/cdt_select_right.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            RegExp acceptedLanguage = new RegExp("s?");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void msgBranchingShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/message_branching.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("server")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            RegExp acceptedLanguage = new RegExp("sr");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+
+        @Test
+        public void msgCdtBranchingMsgShouldReturnSpecificLanguage() throws IOException {
+            var ctx = testFile("behavioursCombinations/msg_cdt_branching_msg.sp").compilerCtx;
+            var clientSession = ctx.sessions.stream().filter(s -> s.peerA().equals("client")).toList().getFirst();
+            var automaton = pattern2DFA(clientSession);
+            automaton.setDeterministic(false);
+            RegExp acceptedLanguage = new RegExp("sr(s|r)");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, automaton);
+        }
+    }
+
+    @Nested
+    class RecursiveTests{
+        @Test
+        public void simpleRecursiveSendWithoutFinalStateShouldNotAcceptSstar(){
+            RegExp acceptedLanguage = new RegExp("(s)*");
+            var a = acceptedLanguage.toAutomaton();
+            var com = new Communication(Utils.Direction.SEND);
+            com.addLeafCommunicationRoots(new ArrayList<>(List.of(com)));
+            Session s = new Session("a","b", com);
+            var auto = pattern2DFA(s);
+            assertNotEquals(a, auto);
+        }
+        @Test
+        public void simpleRecursiveSendWithFinalStateShouldAcceptSplus(){
+            RegExp acceptedLanguage = new RegExp("(s)+");
+            var a = acceptedLanguage.toAutomaton();
+            var com = new Communication(Utils.Direction.SEND);
+            com.addLeafCommunicationRoots(new ArrayList<>(List.of(com, new Communication(VOID))));
+            Session s = new Session("a","b", com);
+            var auto = pattern2DFA(s);
+            assertEquals(a, auto);
+        }
+        @Test
+        public void recursiveSendOrVoidWithFinalStateShouldAcceptSstar(){
+            RegExp acceptedLanguage = new RegExp("(s)*");
+            var a = acceptedLanguage.toAutomaton();
+            var com = new Communication(Utils.Direction.SEND);
+            com.addLeafCommunicationRoots(new ArrayList<>(List.of(com, new Communication(VOID))));
+            Session s = new Session("a","b", new ArrayList<>(List.of(com, new Communication(VOID))));
+            var auto = pattern2DFA(s);
+            assertEquals(a, auto);
+        }
+
+        @Test
+        public void receiveEndOrSendRecursiveShoudNotAcceptSstarR() throws IOException {
+            var ctx = testFile("receive_or_recursive_send.sp").compilerCtx;
+            var s = ctx.sessions.stream().filter(se -> se.peerA().equals("client")).findFirst().get();
+            RegExp acceptedLanguage = new RegExp("(s*)r");
+            var a = acceptedLanguage.toAutomaton();
+            assertEquals(a, pattern2DFA(s));
+        }
+    }
+}

--- a/src/test/java/SessionTest.java
+++ b/src/test/java/SessionTest.java
@@ -9,6 +9,7 @@ import javax.sql.CommonDataSource;
 import java.util.ArrayList;
 import java.util.List;
 
+import static mychor.automata.PatternUtils.pattern2DFA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -646,10 +647,10 @@ public class SessionTest {
                                     new Communication(Utils.Direction.SEND))));
             Session sFalse = new Session("server", "client",
                     new Communication(Utils.Direction.RECEIVE));
-            assertTrue(longSession.supports(s1));
-            assertTrue(longSession.supports(s2));
-            assertTrue(longSession.supports(s3));
-            assertFalse(longSession.supports(sFalse));
+            assertTrue(pattern2DFA(s1).subsetOf(pattern2DFA(longSession)));
+            assertTrue(pattern2DFA(s2).subsetOf(pattern2DFA(longSession)));
+            assertTrue(pattern2DFA(s3).subsetOf(pattern2DFA(longSession)));
+            assertFalse(pattern2DFA(sFalse).subsetOf(pattern2DFA(longSession)));
         }
     }
 


### PR DESCRIPTION
Message patterns are created using regex (a pattern is a regex) and sessions are compared by being turned into FDA and by checking subset relations

Also, the way to build sessions from behaviours was faulty, this was fixed in this PR
